### PR TITLE
feat: add multi-chat viewer for ChatGPT, Claude, and Gemini

### DIFF
--- a/multi_chat_viewer.html
+++ b/multi_chat_viewer.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Multi-Chat Viewer</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: Arial, sans-serif;
+            height: 100vh;
+            overflow: hidden;
+        }
+
+        .header {
+            background-color: #2c3e50;
+            color: white;
+            padding: 10px;
+            text-align: center;
+            font-size: 18px;
+            font-weight: bold;
+        }
+
+        .container {
+            display: flex;
+            height: calc(100vh - 50px);
+            width: 100%;
+        }
+
+        .column {
+            flex: 1;
+            border-right: 2px solid #34495e;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .column:last-child {
+            border-right: none;
+        }
+
+        .column-header {
+            background-color: #34495e;
+            color: white;
+            padding: 8px;
+            text-align: center;
+            font-weight: bold;
+            font-size: 14px;
+        }
+
+        .chatgpt-header {
+            background-color: #10a37f;
+        }
+
+        .claude-header {
+            background-color: #c17c4f;
+        }
+
+        .gemini-header {
+            background-color: #4285f4;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+            width: 100%;
+        }
+
+        .error-message {
+            padding: 20px;
+            text-align: center;
+            color: #e74c3c;
+            font-size: 14px;
+        }
+    </style>
+</head>
+<body>
+    <div class="header">Multi-Chat Viewer - ChatGPT | Claude | Gemini</div>
+    <div class="container">
+        <div class="column">
+            <div class="column-header chatgpt-header">ChatGPT</div>
+            <iframe
+                src="https://chatgpt.com/g/g-p-691b3c7d19b4819183e9a27cd0700bc7-brants-stein-002-be-ep/c/691c9614-b258-832c-8201-88e911ae26f9"
+                title="ChatGPT Chat"
+                sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals"
+                loading="lazy">
+            </iframe>
+        </div>
+
+        <div class="column">
+            <div class="column-header claude-header">Claude</div>
+            <iframe
+                src="https://claude.ai/chat/7e0f1651-33a5-43c0-bca6-be6f4977736b"
+                title="Claude Chat"
+                sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals"
+                loading="lazy">
+            </iframe>
+        </div>
+
+        <div class="column">
+            <div class="column-header gemini-header">Gemini</div>
+            <iframe
+                src="https://gemini.google.com/gem/839507734ccd/3ebe6cf9e3dafd58"
+                title="Gemini Chat"
+                sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-modals"
+                loading="lazy">
+            </iframe>
+        </div>
+    </div>
+
+    <script>
+        // Handle iframe errors
+        document.querySelectorAll('iframe').forEach(iframe => {
+            iframe.onerror = function() {
+                console.error('Failed to load iframe:', iframe.src);
+            };
+        });
+    </script>
+</body>
+</html>

--- a/multi_chat_viewer.py
+++ b/multi_chat_viewer.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Multi-Chat Viewer - Display multiple AI chat pages side by side
+Displays ChatGPT, Claude, and Gemini chats in a three-column layout
+"""
+
+import sys
+from PyQt6.QtCore import QUrl, Qt
+from PyQt6.QtWidgets import (
+    QApplication, QMainWindow, QWidget, QHBoxLayout,
+    QVBoxLayout, QLabel, QSplitter
+)
+from PyQt6.QtWebEngineWidgets import QWebEngineView
+from PyQt6.QtGui import QPalette, QColor
+
+
+class ChatColumn(QWidget):
+    """A column containing a chat interface"""
+
+    def __init__(self, title, url, header_color):
+        super().__init__()
+        self.title = title
+        self.url = url
+        self.header_color = header_color
+        self.init_ui()
+
+    def init_ui(self):
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+
+        # Header label
+        header = QLabel(self.title)
+        header.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        header.setStyleSheet(f"""
+            QLabel {{
+                background-color: {self.header_color};
+                color: white;
+                padding: 8px;
+                font-weight: bold;
+                font-size: 14px;
+            }}
+        """)
+
+        # Web view
+        self.web_view = QWebEngineView()
+        self.web_view.setUrl(QUrl(self.url))
+
+        # Add to layout
+        layout.addWidget(header)
+        layout.addWidget(self.web_view)
+
+        self.setLayout(layout)
+
+
+class MultiChatViewer(QMainWindow):
+    """Main window for the Multi-Chat Viewer"""
+
+    def __init__(self):
+        super().__init__()
+        self.init_ui()
+
+    def init_ui(self):
+        self.setWindowTitle("Multi-Chat Viewer - ChatGPT | Claude | Gemini")
+        self.setGeometry(100, 100, 1800, 1000)
+
+        # Central widget
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+
+        # Main layout
+        main_layout = QVBoxLayout()
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        main_layout.setSpacing(0)
+
+        # Title bar
+        title_bar = QLabel("Multi-Chat Viewer - ChatGPT | Claude | Gemini")
+        title_bar.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        title_bar.setStyleSheet("""
+            QLabel {
+                background-color: #2c3e50;
+                color: white;
+                padding: 10px;
+                font-size: 18px;
+                font-weight: bold;
+            }
+        """)
+        main_layout.addWidget(title_bar)
+
+        # Splitter for resizable columns
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+
+        # Chat URLs
+        chatgpt_url = "https://chatgpt.com/g/g-p-691b3c7d19b4819183e9a27cd0700bc7-brants-stein-002-be-ep/c/691c9614-b258-832c-8201-88e911ae26f9"
+        claude_url = "https://claude.ai/chat/7e0f1651-33a5-43c0-bca6-be6f4977736b"
+        gemini_url = "https://gemini.google.com/gem/839507734ccd/3ebe6cf9e3dafd58"
+
+        # Create columns
+        chatgpt_column = ChatColumn("ChatGPT", chatgpt_url, "#10a37f")
+        claude_column = ChatColumn("Claude", claude_url, "#c17c4f")
+        gemini_column = ChatColumn("Gemini", gemini_url, "#4285f4")
+
+        # Add columns to splitter
+        splitter.addWidget(chatgpt_column)
+        splitter.addWidget(claude_column)
+        splitter.addWidget(gemini_column)
+
+        # Set equal sizes for all columns
+        splitter.setSizes([600, 600, 600])
+
+        # Add splitter to main layout
+        main_layout.addWidget(splitter)
+
+        central_widget.setLayout(main_layout)
+
+        # Set dark theme
+        self.set_dark_theme()
+
+    def set_dark_theme(self):
+        """Apply a dark theme to the application"""
+        palette = QPalette()
+        palette.setColor(QPalette.ColorRole.Window, QColor(53, 53, 53))
+        palette.setColor(QPalette.ColorRole.WindowText, QColor(255, 255, 255))
+        palette.setColor(QPalette.ColorRole.Base, QColor(42, 42, 42))
+        palette.setColor(QPalette.ColorRole.AlternateBase, QColor(66, 66, 66))
+        palette.setColor(QPalette.ColorRole.Text, QColor(255, 255, 255))
+        self.setPalette(palette)
+
+
+def main():
+    """Main entry point"""
+    app = QApplication(sys.argv)
+    app.setApplicationName("Multi-Chat Viewer")
+
+    viewer = MultiChatViewer()
+    viewer.show()
+
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/run_multi_chat.bat
+++ b/run_multi_chat.bat
@@ -1,0 +1,4 @@
+@echo off
+REM Multi-Chat Viewer Launcher
+python multi_chat_viewer.py
+pause


### PR DESCRIPTION
Add three-column chat viewer to display multiple AI chat pages simultaneously:
- HTML version (multi_chat_viewer.html) for quick browser access
- PyQt6 version (multi_chat_viewer.py) with resizable columns and full web engine support
- Batch launcher (run_multi_chat.bat) for easy Windows execution

The viewer displays ChatGPT, Claude, and Gemini chats side-by-side with color-coded headers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a web and PyQt6 multi-chat viewer showing ChatGPT, Claude, and Gemini side-by-side, plus a Windows launcher.
> 
> - **Multi-Chat Viewer**:
>   - **Web (HTML)**: New `multi_chat_viewer.html` rendering three side-by-side chats (`ChatGPT`, `Claude`, `Gemini`) with color-coded headers and sandboxed iframes.
>   - **Desktop (PyQt6)**: New `multi_chat_viewer.py` app with resizable three-column layout (`QSplitter`), embedded `QWebEngineView` for each chat, and a dark theme.
>   - **Launcher**: Add `run_multi_chat.bat` for Windows to start the PyQt app.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8663b1e73ac7f08be5041afcf032da27f3291377. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->